### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/src/python/how2validate/validator.py
+++ b/src/python/how2validate/validator.py
@@ -82,7 +82,7 @@ def main(args=None):
         return
 
     try:
-        logging.info(f"Initiating validation for service: {args.service} with secret: {redact_secret(args.secret)}")
+        logging.info(f"Initiating validation for service: {args.service} with a provided secret.")
         result = validate(args.provider, args.service, args.secret, args.response, args.report)
         logging.info("Validation completed successfully.")
     except Exception as e:


### PR DESCRIPTION
Fixes [https://github.com/Blackplums/how2validate/security/code-scanning/1](https://github.com/Blackplums/how2validate/security/code-scanning/1)

To fix the problem, we should avoid logging any part of the secret, even in a redacted form. Instead, we can log a generic message indicating that a secret is being validated without including the actual secret value. This approach ensures that no sensitive information is exposed in the logs.

- Modify the logging statement on line 85 in `src/python/how2validate/validator.py` to remove the secret from the log message.
- Ensure that the log message still provides useful information without exposing sensitive data.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
